### PR TITLE
Make UI Channel 1 map to MIDI Channel 1 and treat Omni as explicit option

### DIFF
--- a/src/midi/msgtypes.ts
+++ b/src/midi/msgtypes.ts
@@ -71,12 +71,18 @@ export class MidiMessage {
 	get channel(): number {
 		return (this.bytes[0] & 0x0f) + 1
 	}
-	set channel(v: number) {
-		v-- // Channels are normally shown as 1-16 but internally are 0-15
-		v = MidiMessage.constrain(v, 15)
-		this.bytes[0] = (this.bytes[0] & 0xf0) | (v & 0x0f)
-	}
 
+	set channel(v: number) {
+	    if (v === 0) {
+	        // Omni Mode
+	        this.bytes[0] = (this.bytes[0] & 0xf0) | 0
+	        return
+	    }
+	
+	    v = MidiMessage.constrain(v - 1, 15)
+	    this.bytes[0] = (this.bytes[0] & 0xf0) | (v & 0x0f)
+	}
+	
 	protected get data1(): number {
 		return this.bytes[1] & 0x7f
 	}


### PR DESCRIPTION
This update corrects the MIDI channel handling so that UI Channel 1 maps to MIDI Channel 1 instead of MIDI Channel 0 (Omni Mode). The previous behavior caused unintended Omni broadcasts, because MIDI Channel 0 is interpreted by devices as “receive on all channels.” This made normal channel‑based addressing confusing and inconsistent with the MIDI specification.

The change removes the unconditional v-- offset in the channel setter and introduces an explicit, optional Omni Mode only when the user selects Channel 0. All other channels now map directly and predictably to their MIDI equivalents.

Key improvements:

UI Channel 1 → MIDI Channel 1 (correct and intuitive)

No accidental Omni Mode when selecting Channel 1

Omni Mode remains available intentionally via Channel 0

No changes to other message types or value handling

This aligns the module with standard MIDI behavior and prevents unexpected reactions from all devices in a chain.