### PR TITLE
Expose Channel 0 as valid Omni option in UI

### DIFF
--- a/src/operations.ts
+++ b/src/operations.ts
@@ -95,9 +95,9 @@ export function createOptions(newOpts: optionTypes, midiOp: midiMsgType): option
 			{
 				id: 'channel',
 				type: 'number',
-				label: 'Channel',
+				label: 'Channel (0 = Omni)',
 				default: 1,
-				min: 1,
+				min: 0,
 				max: 16,
 				isVisible: (opts) => !opts.useVariables,
 			},


### PR DESCRIPTION
This PR updates the channel option in the module UI to correctly reflect the behavior introduced in PR #28.

Previously, the UI defined the valid channel range as 1–16. As a result, selecting Channel 0 caused the field to be highlighted in red, even though Channel 0 is now intentionally used to represent Omni Mode after the MIDI engine fix.

This update aligns the UI with the corrected MIDI logic by allowing Channel 0 as a valid value and clarifying its meaning in the label. The default remains Channel 1, as Omni Mode is a special case and should not be the default behavior.

Changes:

Allow Channel 0 as a valid input (min: 0)

Update label to clarify that 0 = Omni

Keep default at Channel 1 for predictable, professional MIDI workflows

Impact:

UI no longer marks Channel 0 as invalid

Omni Mode can now be selected intentionally without visual warnings

Behavior is fully consistent with the corrected MIDI channel handling

No other functionality is changed.