### PR TITLE
Add channel-aware noteStates variable for incoming MIDI note tracking

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 	midiOutput!: midi.Output
 	dataStore!: Map<number, number>
 	isRecordingActions!: boolean
+	noteStates!: boolean[]
 
 	constructor(internal: unknown) {
 		super(internal)
@@ -27,6 +28,7 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 	async init(config: ModuleConfig): Promise<void> {
 		this.config = config
 		this.dataStore = new Map()
+		this.noteStates = new Array(128).fill(false)
 
 		this.updateActions()
 		this.updateFeedbacks()
@@ -107,6 +109,7 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 			if (msg.id !== 'mtc') {
 				this.log('debug', `[${deltaTime.toFixed(2).padStart(6, '0')}] Received: ${msg} from "${this.midiInput.name}"`)
 				this.addToDataStore(msg)
+				this.updateNoteStates(msg)
 				if (this.isRecordingActions) this.addToActionRecording(deltaTime, msg)
 			}
 			HandleMidiIndicators(this, 'midiIn')
@@ -120,6 +123,25 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 			this.dataStore.set(data.key, data.val)
 			this.checkAllFeedbacks()
 		}
+	}
+
+	updateNoteStates(msg: MidiMessage): void {
+		if (msg.id !== 'noteon' && msg.id !== 'noteoff') return
+	
+		const note = msg.args.note
+		const velocity = msg.args.velocity
+	
+		if (note === undefined) return
+	
+		if (msg.id === 'noteon' && velocity !== 0) {
+			this.noteStates[note] = true
+		} else {
+			this.noteStates[note] = false
+		}
+	
+		this.setVariableValues({
+			noteStates: this.noteStates,
+		})
 	}
 
 	getFromDataStore(msg: MidiMessage): number | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 	midiOutput!: midi.Output
 	dataStore!: Map<number, number>
 	isRecordingActions!: boolean
-	noteStates!: boolean[]
+	noteStates!: boolean[][]
 
 	constructor(internal: unknown) {
 		super(internal)
@@ -28,7 +28,7 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 	async init(config: ModuleConfig): Promise<void> {
 		this.config = config
 		this.dataStore = new Map()
-		this.noteStates = new Array(128).fill(false)
+		this.noteStates = Array.from({ length: 16 }, () => new Array(128).fill(false))
 
 		this.updateActions()
 		this.updateFeedbacks()
@@ -127,18 +127,23 @@ export default class ModuleInstance extends InstanceBase<InstanceTypes> {
 
 	updateNoteStates(msg: MidiMessage): void {
 		if (msg.id !== 'noteon' && msg.id !== 'noteoff') return
-	
+
 		const note = msg.args.note
 		const velocity = msg.args.velocity
-	
+		const channel = msg.args.channel
+
 		if (note === undefined) return
-	
+		if (velocity === undefined) return
+		if (channel === undefined) return
+
+		const channelIndex = channel - 1
+
 		if (msg.id === 'noteon' && velocity !== 0) {
-			this.noteStates[note] = true
+			this.noteStates[channelIndex][note] = true
 		} else {
-			this.noteStates[note] = false
+			this.noteStates[channelIndex][note] = false
 		}
-	
+
 		this.setVariableValues({
 			noteStates: this.noteStates,
 		})

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -8,7 +8,7 @@ export type midiVars = {
 	lastMessage: string
 	smpte: string
 	smpteFR: number
-	noteStates: boolean[]
+	noteStates: boolean[][]
 }
 
 const variables: CompanionVariableDefinitions<JsonObject> = {
@@ -27,7 +27,7 @@ export function UpdateVariableDefinitions(self: ModuleInstance): void {
 	self.setVariableValues({
 		midiIn: false,
 		midiOut: false,
-		noteStates: new Array(128).fill(false),
+		noteStates: Array.from({ length: 16 }, () => new Array(128).fill(false)),
 	})
 }
 

--- a/src/variables.ts
+++ b/src/variables.ts
@@ -8,6 +8,7 @@ export type midiVars = {
 	lastMessage: string
 	smpte: string
 	smpteFR: number
+	noteStates: boolean[]
 }
 
 const variables: CompanionVariableDefinitions<JsonObject> = {
@@ -16,13 +17,18 @@ const variables: CompanionVariableDefinitions<JsonObject> = {
 	lastMessage: { name: 'Last Message Received' },
 	smpte: { name: 'SMPTE TC from MTC' },
 	smpteFR: { name: 'SMPTE Frame Rate from MTC' },
+	noteStates: { name: 'Current Note States' },
 }
 
 const midiTimers: Map<string, ReturnType<typeof setTimeout> | null> = new Map()
 
 export function UpdateVariableDefinitions(self: ModuleInstance): void {
 	self.setVariableDefinitions(variables)
-	self.setVariableValues({ midiIn: false, midiOut: false })
+	self.setVariableValues({
+		midiIn: false,
+		midiOut: false,
+		noteStates: new Array(128).fill(false),
+	})
 }
 
 export function HandleMidiIndicators(self: ModuleInstance, variable: string): void {


### PR DESCRIPTION
## Summary

Adds a new `noteStates` variable which exposes the current state of incoming MIDI notes.

Format:

`noteStates[channel][note]`

Features:

* Tracks note state independently per MIDI channel
* Supports all MIDI note numbers (0-127)
* Updates automatically from incoming Note On and Note Off messages
* Treats Note On with velocity 0 as Note Off

Example:

`$(generic-midi:noteStates)[0][60]`

Returns the current state of MIDI Note 60 on MIDI Channel 1.
